### PR TITLE
Added haxelib file

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,12 @@
+{
+   "name": "vdebug",
+   "url": "https://github.com/marcgardent/armory3D-VDebug",
+   "license": "MIT",
+   "classPath": "Sources",
+   "tags": [],
+   "description": "Lib Armory3D to draw debug infos on the screen",
+   "contributors": ["marcgardent"],
+   "releasenote": "Added haxelib file",
+   "version": "1.0.0",
+   "dependencies": {}
+}


### PR DESCRIPTION
It seems that Armory requires haxelib file to use it as a library